### PR TITLE
Add uutf dependency, bump minimum torch version

### DIFF
--- a/bert.opam
+++ b/bert.opam
@@ -13,8 +13,9 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "base" {>= "v0.14"}
   "cmdliner"
+  "uutf"
   "dune" {>= "1.3.0" build}
-  "torch" {= "0.9"}
+  "torch" {>= "0.10"}
   "ocaml" {>= "4.08"}
   "ppx_custom_printf" {>= "v0.14"}
   "ppx_expect" {>= "v0.14"}


### PR DESCRIPTION
This patch
1. adds the uutf dependency, needed by bert.tokenize,
2.  bumps the torch dependency, as I believe the [layer norm change](https://github.com/LaurentMazare/ocaml-torch/commit/16a70868af32f89a95adf4d0f76766cb1efe0ca0#diff-1a314569af425a620aa99ea35f0120317baf8b0d1023e1653a3220f09effeba9) used needs at least [torch version 0.10](
https://github.com/LaurentMazare/ocaml-torch/commit/0eb57ac4de5fb187dfcbd8e09b31b6c0cf70df1d#diff-0352aeadab590c77bdce7e706731d792291f407fa2885424d325ad0d4451fe84)

(Also, a great thank you for enabling doing NLP in OCaml by the way)

[uutf_failure.txt](https://github.com/LaurentMazare/ocaml-bert/files/6450632/uutf_failure.txt)
[torch_0.9_failure.txt](https://github.com/LaurentMazare/ocaml-bert/files/6450634/torch_0.9_failure.txt)